### PR TITLE
Increase accuracy of dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,7 @@ import { WebpackConfigDumpPlugin } from "webpack-config-dump-plugin";
   outputPath: './',
 
   // Config dump filename
-  name: 'webpack.config.dump',
-
-  // Config depth. Since webpack config is circulary locked,
-  // we can't dump whole config. This parameter sets how deep
-  // config dump will be stored
-  depth: 4
+  name: 'webpack.config.dump'
 
 }
 ```

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 A webpack plugin to dump compiled webpack config into file system. Is useful in case
 you have resolve aliases formed dynamically and want your IDE to be able to handle them.
 
-**Note that functions will be excluded from the final dump**.
-
 #### For typescript config file you can use [webpack-typescript-config-dump-plugin](https://www.npmjs.com/package/webpack-typescript-config-dump-plugin)
 
 ### In version 2 the plugin has been rewritten using Typescript language. Now it needs to be imported as ES module (check the installation guide for details)

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -91,23 +91,27 @@ describe("Dump webpack config", () => {
       expect(output).toEqual({ foo: /foo/, bar: /bar/ });
     });
 
-    it("Keeps numbers with values", () => {
+    it("Keeps numbers", () => {
       const output = plugin.simplifyConfig({ foo: 9000, bar: 0 });
-      expect(output).toEqual({ foo: 9000 });
+      expect(output).toEqual({ foo: 9000, bar: 0 });
     });
 
-    it("Keeps strings with values", () => {
+    it("Keeps strings", () => {
       const output = plugin.simplifyConfig({ foo: "bar", bar: "" });
-      expect(output).toEqual({ foo: "bar" });
+      expect(output).toEqual({ foo: "bar", bar: "" });
     });
 
-    it("Keeps non-empty arrays", () => {
+    it("Keeps arrays", () => {
       const output = plugin.simplifyConfig({
         foo: [],
         bar: ["test"],
         some: [""],
       });
-      expect(output).toEqual({ bar: ["test"] });
+      expect(output).toEqual({
+        foo: [],
+        bar: ["test"],
+        some: [""]
+      });
     });
 
     it("Keeps nested objects", () => {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -78,9 +78,9 @@ describe("Dump webpack config", () => {
       expect(output).toEqual(undefined);
     });
 
-    it("Cuts function", () => {
+    it("Keeps functions", () => {
       const output = plugin.simplifyConfig({ foo: () => {} });
-      expect(output).toEqual({});
+      expect(output).toEqual({ foo: "[Function: foo]" });
     });
 
     it("Keeps RegExp", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,10 @@ export class WebpackConfigDumpPlugin {
     map.set(config, `<<circular reference to ${key}>>`);
   }
 
+  private isValidConfigValue(value: any) {
+    return value !== undefined && value !== null;
+  }
+
   private simplifyLevel(config: any, map: Map<any, string>, currentKey = '') {
     if (isFunction(config)) {
       if (config.name) {
@@ -72,13 +76,13 @@ export class WebpackConfigDumpPlugin {
       this.addLevelToMap(map, currentKey, config);
       const formattedLevel = config.reduce((res, item, index) => {
         const value = this.simplifyLevel(item, map, `${currentKey}[${index}]`);
-        if (value) {
+        if (this.isValidConfigValue(value)) {
           res.push(value);
         }
         return res;
       }, []);
       map.delete(config);
-      return formattedLevel.length ? formattedLevel : null;
+      return formattedLevel;
     }
 
     if (isRegExp(config)) {
@@ -90,7 +94,7 @@ export class WebpackConfigDumpPlugin {
       return Object.keys(config).reduce((res, key) => {
         const newKey = `${currentKey}["${key.replace(/"/g, "\\\"")}"]`;
         const value = this.simplifyLevel(config[key], map, newKey);
-        if (value) {
+        if (this.isValidConfigValue(value)) {
           res[key] = value;
         }
         return res;

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,10 @@ export class WebpackConfigDumpPlugin {
 
   private simplifyLevel(config: any, map: Map<any, string>, currentKey = '') {
     if (isFunction(config)) {
-      return null;
+      if (config.name) {
+        return `[Function: ${config.name}]`;
+      }
+      return "[Function]";
     }
 
     if (map.has(config)) {


### PR DESCRIPTION
This started out as a change for #11. I have included other changes that make the dump more accurate, if you need me to split up the PR instead or pull some things out let me know.

Changes:
- Instead of specifying depth, if the plugin finds a circular key, it dumps a string: `'<<circular reference too ["foo"][0]["bar"]>>'`
- Instead of not printing functions, it dumps a string: `'[Function: (name)]'` or `'[Function]'`
- It now dumps falsy values other than undefined and null. This is because `{ myPlugin: { foo: "bar", numericOption: 0 } }` is not the same as `{ myPlugin: { foo: "bar" } }`, `{ myPlugin: { foo: "bar", defaultTrueOption: false } }` is not the same as `{ myPlugin: { foo: "bar" } }`, `{ foo: "bar", myPlugin: [[""], 0, false] }` is not the same as `{foo: "bar" }`, etc.