### PR TITLE
fix(deps): Recover build structure (Closes #18)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webpack-config-dump-plugin",
   "description": "A webpack plugin to cache compiled webpack config on the file system",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "author": "Sergey Nikitin <srg.post@gmail.com>",
   "license": "MIT",
   "main": "dist/index.js",
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "format": "prettier --write .",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "test": "jest",
     "coverage": "jest --collect-coverage",
     "test:watch": "jest --watch --silent=false",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig",
+  "exclude": ["**/*.spec.ts", "**/__mocks__/*"]
+}


### PR DESCRIPTION
With latest dependencies update I have included the spec files and mock into typechecking. This eventually changes the build structure emitted by Typescript, and hence made all the package imports unavailable.

With this fix we create a build tsconfig, which excludes spec files, so recovers the old dist output. In the meantime in development we still typecheck spec files.